### PR TITLE
Update build.sh

### DIFF
--- a/halo2-wasm/template/build.sh
+++ b/halo2-wasm/template/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-rm -r pkg
+rm -rf pkg
 
 TARGET=$1
 


### PR DESCRIPTION
Getting an error when first running this script when pkg/ folder is not there.
Updated to force rm (whcih doesn't error out if pkg/ doesn't exist) to fix this bug