### PR TITLE
fix wasm template build.sh script

### DIFF
--- a/halo2-wasm/template/Cargo.toml
+++ b/halo2-wasm/template/Cargo.toml
@@ -18,3 +18,6 @@ halo2-wasm = { git = "https://github.com/axiom-crypto/halo2-wasm.git", default-f
 [features]
 default=["rayon"]
 rayon=["halo2-wasm/rayon"]
+
+# don't remove. needed to make ./build.sh work
+[workspace]


### PR DESCRIPTION
Not sure this is the right solution, but this worked for me.
When running the `build.sh` script without this [workspace] section, I was getting
```
Error: `cargo metadata` exited with an error: error: current package believes it's in a workspace when it's not:
current:   /Users/samlaf/devel/zk/axiom/halo2-browser/halo2-wasm/template/Cargo.toml
workspace: /Users/samlaf/devel/zk/axiom/halo2-browser/Cargo.toml

this may be fixable by adding `halo2-wasm/template` to the `workspace.members` array of the manifest located at: /Users/samlaf/devel/zk/axiom/halo2-browser/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.

Caused by: `cargo metadata` exited with an error: error: current package believes it's in a workspace when it's not:
current:   /Users/samlaf/devel/zk/axiom/halo2-browser/halo2-wasm/template/Cargo.toml
workspace: /Users/samlaf/devel/zk/axiom/halo2-browser/Cargo.toml

this may be fixable by adding `halo2-wasm/template` to the `workspace.members` array of the manifest located at: /Users/samlaf/devel/zk/axiom/halo2-browser/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```