### PR TITLE
Fix halo2-wasm template struct name

### DIFF
--- a/halo2-wasm/template/src/lib.rs
+++ b/halo2-wasm/template/src/lib.rs
@@ -18,7 +18,7 @@ impl MyCircuit {
     #[wasm_bindgen(constructor)]
     pub fn new(circuit: &Halo2Wasm) -> Self {
         let gate = GateChip::new();
-        Halo2WasmTemplate {
+        MyCircuit {
             gate,
             builder: Arc::clone(&circuit.circuit),
         }


### PR DESCRIPTION
This PR adds a little fix for the template to return the `MyCircuit` circuit rather than `Halo2WasmTemplate` which I think that was the initial intention. 