### PR TITLE
Update LICENSE for 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Axiom
+Copyright (c) 2025 Axiom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/halo2-lib-js/LICENSE
+++ b/halo2-lib-js/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Axiom
+Copyright (c) 2025 Axiom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/halo2-repl/LICENSE
+++ b/halo2-repl/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Axiom
+Copyright (c) 2025 Axiom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/halo2-wasm/LICENSE
+++ b/halo2-wasm/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Axiom
+Copyright (c) 2025 Axiom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Description:
This pull request updates the LICENSE files across multiple directories to reflect the updated copyright year from 2023 to 2025.

### Comment:
The copyright year has been updated in the LICENSE files for the following directories:
- `halo2-wasm`
- `halo2-lib-js`
- `halo2-repl`
- `halo2-wasm-cli`

This update ensures that all files are in line with the current year.

### Preview:
- The copyright year has been updated in each LICENSE file to "Copyright (c) 2025 Axiom".